### PR TITLE
Reorder of supertypes in Reflection.java

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/Reflection.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/Reflection.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,7 +136,7 @@ public final class Reflection {
     }
 
     public static Set<Type<?>> supertypes(Type<?> bottom) {
-        Set<Type<?>> supertypes = new HashSet<>();
+        Set<Type<?>> supertypes = new LinkedHashSet<>();
         supertypes.add(bottom);
         supertypes.addAll(bottom.getAllTypesAssignableFromThis());
         return supertypes;


### PR DESCRIPTION
The test SetOfSuperFloatPropertyParameterTest.producesExpectedRandomValues compares the results with float data types.
The function Items.choose does not return the deterministic object during its random selection. This is a Flaky test and used NonDex to reproduce flaky tests. From code trace, the root cause is the method Reflection.supertypes, which returns a HashSet of the supertypes of a certain type.  With no guarantee in order in which the supertypes returns, it can cause the test to fail due to selecting the wrong data generator. 

This PR proposes to modify the data structure and to reorder the data types so that during the conversion in Items.choose function the line that does the toArray() will maintain the order of the elements.